### PR TITLE
Added a shell sourcing note to ensure_path

### DIFF
--- a/src/pipx/commands/common.py
+++ b/src/pipx/commands/common.py
@@ -479,7 +479,7 @@ def warn_if_not_on_path(local_bin_dir: Path) -> None:
                 environment variable. These apps will not be globally
                 accessible until your PATH is updated. Run `pipx ensurepath` to
                 automatically add it, or manually modify your PATH in your
-                shell's config file (i.e. ~/.bashrc).
+                shell's config file (e.g. ~/.bashrc).
                 """,
                 subsequent_indent=" " * 4,
             )

--- a/src/pipx/commands/ensure_path.py
+++ b/src/pipx/commands/ensure_path.py
@@ -84,7 +84,8 @@ def ensure_path(location: Path, *, force: bool) -> Tuple[bool, bool]:
                 f"""
                 {location_str} has been been added to PATH, but you need to
                 open a new terminal or re-login for this PATH change to take
-                effect.
+                effect. Alternatively, you can source your shell's config file
+                with e.g. 'source ~/.bashrc'.
                 """,
                 subsequent_indent=" " * 4,
             )
@@ -140,7 +141,8 @@ def ensure_pipx_paths(force: bool) -> ExitCode:
             pipx_wrap(
                 """
                 You will need to open a new terminal or re-login for the PATH
-                changes to take effect.
+                changes to take effect. Alternatively, you can source your shell's
+                config file with e.g. 'source ~/.bashrc'.
                 """
             )
             + "\n"


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->

- [ ] I have added a news fragment under `changelog.d/` (if the patch affects the end users)

## Summary of changes

## Test plan

<!-- provide evidence of testing, preferably with command(s) that can be copy+pasted by others -->

Tested by running

```
# command(s) to exercise these changes
```
